### PR TITLE
config: log config file re-reads

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use log::error;
+use log::{error, info};
 use serde::Deserialize;
 
 mod duration_human;
@@ -100,6 +100,7 @@ impl Inner {
                 Ok(cf) => {
                     self.config_file = cf;
                     self.last_modified = last_modified;
+                    info!("Re-read config file {}", self.path.display());
                 }
                 Err(e) => {
                     error!("Failed to re-read config: {e}. Re-using previous version.");


### PR DESCRIPTION
Being certain that the config file was actually re-read is invaluable when debugging issues with e.g. new machines.

This has not been runtime-tested, but the change should be small enough that `cargo clippy` being satisfied should be enought.