### PR TITLE
contrib: setup_templates: clean up the cloud-init configuration

### DIFF
--- a/contrib/setup_templates/generic/cloud-init/user-data
+++ b/contrib/setup_templates/generic/cloud-init/user-data
@@ -4,30 +4,19 @@ users:
   - name: runner
     sudo: "ALL=(ALL) NOPASSWD:ALL"
 
+write_files:
+  - path: /etc/systemd/system/serial-getty@ttyS1.service.d/override.conf
+    content: |
+      # Provide a root shell on the secondary serial device
+      # (the one connected to shell.sock on the outside).
+
+      [Service]
+      ExecStart=
+      ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
+
 runcmd:
-  - |
-    set -e -u
-
-    # Provide a root shell on the secondary serial device
-    # (the one connected to shell.sock on the outside).
-
-    GETTY_SERVICE="serial-getty@ttyS1.service"
-    GETTY_DIR="/etc/systemd/system/${GETTY_SERVICE}.d/"
-    GETTY_OVERRIDE="${GETTY_DIR}/override.conf"
-
-    if ! test -e "${GETTY_OVERRIDE}"
-    then
-        mkdir -p "${GETTY_DIR}"
-        cat > "${GETTY_OVERRIDE}" << 'EOF'
-    [Service]
-    ExecStart=
-    ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
-    EOF
-
-        systemctl daemon-reload
-        systemctl enable --now --no-block "${GETTY_SERVICE}"
-    fi
-
+  - systemctl daemon-reload
+  - systemctl enable --now --no-block "serial-getty@ttyS1.service"
   - |
     set -e -u
 

--- a/contrib/setup_templates/generic/cloud-init/user-data
+++ b/contrib/setup_templates/generic/cloud-init/user-data
@@ -45,7 +45,6 @@ runcmd:
     After=network.target cloud-final.service
 
     [Service]
-    ExecStartPre=+/usr/bin/cloud-init status --wait
     ExecStartPre=+/usr/bin/mount -o rw,fmask=0022,dmask=0022,uid=runner,gid=runner --mkdir /dev/disk/by-label/JOBDATA /home/runner/config
     ExecStart=/home/runner/config/job.sh
     ExecStopPost=+/usr/bin/systemctl poweroff

--- a/contrib/setup_templates/generic/cloud-init/user-data
+++ b/contrib/setup_templates/generic/cloud-init/user-data
@@ -14,42 +14,27 @@ write_files:
       ExecStart=
       ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
 
+  - path: /etc/systemd/system/github-action-runner.service
+    content: |
+      [Unit]
+      Description=GitHub JIT Runner
+      After=network.target cloud-final.service
+
+      [Service]
+      ExecStart=/home/runner/config/job.sh
+      ExecStopPost=+/usr/bin/systemctl poweroff
+      StandardOutput=journal+console
+      StandardError=journal+console
+      User=runner
+      WorkingDirectory=/home/runner
+      KillMode=process
+      KillSignal=SIGTERM
+      TimeoutStopSec=5min
+
+      [Install]
+      WantedBy=cloud-init.target
+
 runcmd:
   - systemctl daemon-reload
-  - systemctl enable --now --no-block "serial-getty@ttyS1.service"
-  - |
-    set -e -u
-
-    # Set up a service that mounts the job config file system and runs the job
-    # script inside of it under the `runner` user.
-
-    SERVICE_FILE="github-action-runner.service"
-    SERVICE_PATH="/etc/systemd/system/${SERVICE_FILE}"
-
-    if ! test -e "${SERVICE_PATH}"
-    then
-        cat > "${SERVICE_PATH}" << 'EOF'
-    [Unit]
-    Description=GitHub JIT Runner
-    After=network.target cloud-final.service
-
-    [Service]
-    ExecStartPre=+/usr/bin/mount -o rw,fmask=0022,dmask=0022,uid=runner,gid=runner --mkdir /dev/disk/by-label/JOBDATA /home/runner/config
-    ExecStart=/home/runner/config/job.sh
-    ExecStopPost=+/usr/bin/systemctl poweroff
-    StandardOutput=journal+console
-    StandardError=journal+console
-    User=runner
-    WorkingDirectory=/home/runner
-    KillMode=process
-    KillSignal=SIGTERM
-    TimeoutStopSec=5min
-
-    [Install]
-    WantedBy=cloud-init.target
-    EOF
-
-        systemctl daemon-reload
-        systemctl enable "${SERVICE_FILE}"
-        systemctl start --no-block "${SERVICE_FILE}"
-    fi
+  - systemctl enable --now --no-block serial-getty@ttyS1.service
+  - systemctl enable --now --no-block github-action-runner.service

--- a/contrib/setup_templates/generic/cloud-init/user-data
+++ b/contrib/setup_templates/generic/cloud-init/user-data
@@ -14,11 +14,22 @@ write_files:
       ExecStart=
       ExecStart=-/sbin/agetty --autologin root --noclear %I $TERM
 
+  - path: /etc/systemd/system/home-runner-config.mount
+    content: |
+      [Unit]
+      Description=Forrest Job config filesystem mount
+
+      [Mount]
+      What=/dev/disk/by-label/JOBDATA
+      Where=/home/runner/config
+      Options=rw,fmask=0022,dmask=0022,uid=runner,gid=runner
+
   - path: /etc/systemd/system/github-action-runner.service
     content: |
       [Unit]
       Description=GitHub JIT Runner
-      After=network.target cloud-final.service
+      After=network.target cloud-final.service home-runner-config.mount
+      Requires=home-runner-config.mount
 
       [Service]
       ExecStart=/home/runner/config/job.sh

--- a/contrib/setup_templates/generic/cloud-init/user-data
+++ b/contrib/setup_templates/generic/cloud-init/user-data
@@ -6,18 +6,6 @@ users:
 
 runcmd:
   - |
-    # Disable the ssh service on the machine.
-    # This should work with both Debian an Arch Linux machines.
-
-    for service in sshd.service ssh.service
-    do
-      if [ -e "/usr/lib/systemd/system/${service}" ]
-      then
-          systemctl disable --now --no-block "${service}"
-      fi
-    done
-
-  - |
     set -e -u
 
     # Provide a root shell on the secondary serial device


### PR DESCRIPTION
This cleans up various aspects of the default `cloud-init` configuration.

I will leave this as a draft until I get around to test it.