### PR TITLE
ingres: poll: do not poll before notifying systemd

### DIFF
--- a/src/ingres/poll.rs
+++ b/src/ingres/poll.rs
@@ -160,7 +160,7 @@ impl Poller {
     /// How far back to go in the run history is decided by `MAX_NEW_RUN_AGE`,
     /// the most recent run id already known for the repository and the list
     /// of runs the `create::jobs::Manager` is interested in.
-    pub async fn poll_once(&self) -> octocrab::Result<()> {
+    async fn poll_once(&self) -> octocrab::Result<()> {
         let cfg = self.config.get();
 
         // These are runs for which we have jobs in "interesting" states,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,6 @@ async fn forrest() -> anyhow::Result<()> {
     // missed webhooks.
     let poller = ingres::Poller::new(config.clone(), auth.clone(), job_manager);
 
-    // Make sure we can reach GitHub and our authentication works before
-    // signaling readiness to systemd.
-    poller.poll_once().await?;
-
     log::info!("Startup complete. Handling requests");
 
     // Notify systemd that we are ready to handle requests.


### PR DESCRIPTION
We poll each user, repository, run and job in sequence. This can take rather long when a lot of repositories are configured, in fact too long for the default systemd job startup timeout.

There is no real benefit to delaying the startup notification until after the first of polling, so just don't do it instead. This speeds up the perceived startup a lot.

Fixes #6.