### PR TITLE
ingres: poll: only poll runs from the last 24 hours in initial poll

### DIFF
--- a/src/ingres/poll.rs
+++ b/src/ingres/poll.rs
@@ -12,7 +12,7 @@ use crate::machines::OwnerAndRepo;
 
 /// The cut-off point when fetching the initial run list.
 /// Once a run is encountered that is older than this the search will stop.
-const MAX_NEW_RUN_AGE: TimeDelta = TimeDelta::days(7);
+const MAX_NEW_RUN_AGE: TimeDelta = TimeDelta::days(1);
 
 pub struct Poller {
     auth: Arc<Auth>,


### PR DESCRIPTION
First of all: this does not affect runs that the Forrest instance already knows about. This is only the initial scan for runs that need our attention.

There can not be any runs older than 24 hours that need our attention, because GitHub cancels jobs for which no runner has registered after 24 hours.

Fixes #7.