### PR TITLE
jobs/machines: manager: simplify logic using HashMap::entry()

### DIFF
--- a/src/jobs/manager.rs
+++ b/src/jobs/manager.rs
@@ -51,12 +51,7 @@ impl Manager {
                 let oar = job.triplet().clone().into_owner_and_repo();
                 let run_id = job.run_id();
 
-                if let Some(run_ids) = res.get_mut(&oar) {
-                    run_ids.insert(run_id);
-                } else {
-                    let run_ids = HashSet::from_iter([run_id]);
-                    res.insert(oar, run_ids);
-                }
+                res.entry(oar).or_default().insert(run_id);
             }
         }
 

--- a/src/machines/manager.rs
+++ b/src/machines/manager.rs
@@ -102,11 +102,9 @@ impl Manager {
         let mut demand: HashMap<Triplet, u64> = HashMap::new();
 
         for triplet in requested {
-            if let Some(count) = demand.get_mut(triplet) {
-                *count += 1
-            } else {
-                demand.insert(triplet.clone(), 1);
-            }
+            let count = demand.entry(triplet.clone()).or_insert(0);
+
+            *count += 1;
         }
 
         debug!("Updating the machine demand with:");
@@ -148,17 +146,13 @@ impl Manager {
         let cfg = self.config.get();
 
         for (triplet, count) in demand {
-            if !machines.contains_key(&triplet) {
-                machines.insert(triplet.clone(), Vec::new());
-            }
-
             for _ in 0..count {
                 let cfg = cfg.clone();
                 let auth = self.auth.clone();
                 let rescheduler = self.rescheduler();
 
                 if let Some(m) = Machine::new(cfg, auth, rescheduler, triplet.clone()) {
-                    machines.get_mut(&triplet).unwrap().push(m);
+                    machines.entry(triplet.clone()).or_default().push(m);
                 }
             }
         }


### PR DESCRIPTION
Use the magic that is [`HashMap::entry()`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry) to simplify the logic in two places.

This does not even use [`OccupiedEntry`](https://doc.rust-lang.org/std/collections/hash_map/struct.OccupiedEntry.html)/[`VacantEntry`](https://doc.rust-lang.org/std/collections/hash_map/struct.VacantEntry.html) yet. Can't wait to have a use case for those!

Fixes #11.